### PR TITLE
Replacing BinaryFormatter with JsonConverter

### DIFF
--- a/src/Quartz.Spi.MongoDbJobStore/Quartz.Spi.MongoDbJobStore.csproj
+++ b/src/Quartz.Spi.MongoDbJobStore/Quartz.Spi.MongoDbJobStore.csproj
@@ -1,15 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net462;netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>Quartz.Spi.MongoDbJobStore</AssemblyName>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.4.2" />
-    <PackageReference Include="Quartz" Version="3.0.4" />
-    <PackageReference Include="Common.Logging" Version="3.4.1" />
+	<PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+	<PackageReference Include="Quartz" Version="3.4.0" />
+	<PackageReference Include="Quartz.Serialization.Json" Version="3.4.0" />
+	<PackageReference Include="Common.Logging" Version="3.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Quartz.Spi.MongoDbJobStore/Serializers/DefaultObjectSerializer.cs
+++ b/src/Quartz.Spi.MongoDbJobStore/Serializers/DefaultObjectSerializer.cs
@@ -1,6 +1,5 @@
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-
+using System.Text;
+using Newtonsoft.Json;
 using Quartz.Spi;
 
 namespace Quartz.Simpl
@@ -12,6 +11,8 @@ namespace Quartz.Simpl
     /// <author>Marko Lahma</author>
     public class DefaultObjectSerializer : IObjectSerializer
     {
+        JsonSerializerSettings settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
         public void Initialize()
         {
         }
@@ -23,12 +24,8 @@ namespace Quartz.Simpl
         /// <param name="obj">Object to serialize.</param>
         public byte[] Serialize<T>(T obj) where T : class
         {
-            using (MemoryStream ms = new MemoryStream())
-            {
-                BinaryFormatter bf = new BinaryFormatter();
-                bf.Serialize(ms, obj);
-                return ms.ToArray();
-            }
+            string serializedData = JsonConvert.SerializeObject(obj, settings);
+            return Encoding.ASCII.GetBytes(serializedData);
         }
 
         /// <summary>
@@ -37,11 +34,8 @@ namespace Quartz.Simpl
         /// <param name="data">Data to deserialize object from.</param>
         public T DeSerialize<T>(byte[] data) where T : class
         {
-            using (MemoryStream ms = new MemoryStream(data))
-            {
-                BinaryFormatter bf = new BinaryFormatter();
-                return (T)bf.Deserialize(ms);
-            }
+            string str = Encoding.ASCII.GetString(data);
+            return JsonConvert.DeserializeObject<T>(str, settings);
         }
     }
 }

--- a/src/Quartz.Spi.MongoDbJobStore/Serializers/DefaultObjectSerializer.cs
+++ b/src/Quartz.Spi.MongoDbJobStore/Serializers/DefaultObjectSerializer.cs
@@ -11,7 +11,7 @@ namespace Quartz.Simpl
     /// <author>Marko Lahma</author>
     public class DefaultObjectSerializer : IObjectSerializer
     {
-        JsonSerializerSettings settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+        JsonSerializerSettings serializerSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
 
         public void Initialize()
         {
@@ -24,8 +24,8 @@ namespace Quartz.Simpl
         /// <param name="obj">Object to serialize.</param>
         public byte[] Serialize<T>(T obj) where T : class
         {
-            string serializedData = JsonConvert.SerializeObject(obj, settings);
-            return Encoding.ASCII.GetBytes(serializedData);
+            string serializedData = JsonConvert.SerializeObject(obj, serializerSettings);
+            return Encoding.UTF8.GetBytes(serializedData);
         }
 
         /// <summary>
@@ -34,8 +34,8 @@ namespace Quartz.Simpl
         /// <param name="data">Data to deserialize object from.</param>
         public T DeSerialize<T>(byte[] data) where T : class
         {
-            string str = Encoding.ASCII.GetString(data);
-            return JsonConvert.DeserializeObject<T>(str, settings);
+            string str = Encoding.UTF8.GetString(data);
+            return JsonConvert.DeserializeObject<T>(str, serializerSettings);
         }
     }
 }

--- a/src/Quartz.Spi.MongoDbJobStore/Util/LogicalThreadContext.cs
+++ b/src/Quartz.Spi.MongoDbJobStore/Util/LogicalThreadContext.cs
@@ -31,7 +31,7 @@ using System.Security;
 // Workaround for getting off remoting removed in NET Core: http://www.cazzulino.com/callcontext-netstandard-netcore.html
 #if NET452
 using System.Runtime.Remoting.Messaging;
-#elif NET462 || NETSTANDARD2_0
+#elif NET462 || NETSTANDARD2_0 || NET6_0
 using System.Threading;
 #endif
 
@@ -51,7 +51,7 @@ namespace Quartz.Util
         /// <param name="name">The name of the item.</param>
         /// <returns>The object in the call context associated with the specified name or null if no object has been stored previously</returns>
 
-#if NET462 || NETSTANDARD2_0
+#if NET462 || NETSTANDARD2_0 || NET6_0
         static ConcurrentDictionary<string, AsyncLocal<object>> state = new ConcurrentDictionary<string, AsyncLocal<object>>();
 #endif
 
@@ -59,7 +59,7 @@ namespace Quartz.Util
         {
 #if NET452
             return (T)CallContext.GetData(name);
-#elif NET462 || NETSTANDARD2_0
+#elif NET462 || NETSTANDARD2_0 || NET6_0
             return state.TryGetValue(name, out AsyncLocal<object> data) ? (T)data.Value : default(T);
 #endif
         }
@@ -73,7 +73,7 @@ namespace Quartz.Util
         {
 #if NET452
             CallContext.SetData(name, value);
-#elif NET462 || NETSTANDARD2_0
+#elif NET462 || NETSTANDARD2_0 || NET6_0
             state.GetOrAdd(name, _ => new AsyncLocal<object>()).Value = value;
 #endif
         }
@@ -86,7 +86,7 @@ namespace Quartz.Util
         {
 #if NET452
             CallContext.FreeNamedDataSlot(name);
-#elif NET462 || NETSTANDARD2_0
+#elif NET462 || NETSTANDARD2_0 || NET6_0
             state.TryRemove(name, out AsyncLocal<object> discard);
 #endif
         }

--- a/tests/Quartz.Spi.MongoDbJobStore.Tests/ObjectExtensions.cs
+++ b/tests/Quartz.Spi.MongoDbJobStore.Tests/ObjectExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+﻿using Newtonsoft.Json;
 
 namespace Quartz.Util
 {
@@ -14,18 +13,10 @@ namespace Quartz.Util
         /// <param name="obj"></param>
         public static T DeepClone<T>(this T obj) where T : class
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            BinaryFormatter bf = new BinaryFormatter();
-            using (MemoryStream ms = new MemoryStream())
-            {
-                bf.Serialize(ms, obj);
-                ms.Seek(0, SeekOrigin.Begin);
-                return (T)bf.Deserialize(ms);
-            }
+            if (obj == null) return default(T);
+            var clonedObj = JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(obj));
+            clonedObj = obj;
+            return clonedObj;
         }
     }
 }

--- a/tests/Quartz.Spi.MongoDbJobStore.Tests/Quartz.Spi.MongoDbJobStore.Tests.csproj
+++ b/tests/Quartz.Spi.MongoDbJobStore.Tests/Quartz.Spi.MongoDbJobStore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net462;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net462;netstandard2.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Quartz.Spi.MongoDbJobStore.Tests</RootNamespace>
     <AssemblyName>Quartz.Spi.MongoDbJobStore.Tests</AssemblyName>


### PR DESCRIPTION
BinaryFormatter is obselete since .net5.0 due to security issues. 
BinaryFormatter is used in DefaultSerializer.cs for Serializing and Deserializing objects which is now replaced with Newtonsoft.Json serialization object in this PR.
Also in Tests, BinaryFormatter is used in ObjectExtensions.cs to clone an object which is also done using JsonConverter.
